### PR TITLE
Add support for handling a group of controls. 

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -68,7 +68,7 @@
         }
         
         if (error) {
-          el.addClass('unhappy').before(errorEl);
+          el.addClass('unhappy').first().before(errorEl);
           return false;
         } else {
           temp = errorEl.get(0);
@@ -80,7 +80,7 @@
           return true;
         }
       };
-      field.bind(config.when || 'blur', field.testValid);
+      field.bind(opts.when || config.when || 'blur', field.testValid);
     }
     
     for (item in config.fields) {


### PR DESCRIPTION
These changes allow Happy.js to be happy when validating a collection of controls, e.g., $('[name="radios"]').

The current version of the code adds the error label against each control in the collection, but removes it only from the first child (`.get(0)` on line 74).

The second change allow fields to override the default validation event. Useful, again, for radios/checkboxes where you'd like to have `when: 'click'`, but still keep the default `blur` for the rest of the controls.
