### PR TITLE
Wrap `testValid` in an anonymous function that doesn't return a value. 

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -80,7 +80,9 @@
           return true;
         }
       };
-      field.bind(config.when || 'blur', field.testValid);
+      field.bind(config.when || 'blur', function() {
+        field.testValid();
+      });
     }
     
     for (item in config.fields) {


### PR DESCRIPTION
This allows custom `when` events, such as `click`, to perform the default action even if there is a validation error (e.g., click on a checkbox will untick even if the validation requires the box to be ticked).

The current behaviour has `return false` in the validation which acts as `event.preventDefault()`.

Likely to conflict with pull #8 and will require manual merge. The line should be:

```
      field.bind(opts.when || config.when || 'blur', function() {
```
