### PR TITLE
Allow any selector when building an ID for the error element. 

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -30,7 +30,7 @@
       var field = $(selector),
         error = {
           message: opts.message,
-          id: selector.slice(1) + '_unhappy'
+          id: selector.replace(/[^A-Z0-9_\-]+/ig, '_').replace(/_+/g, '_').replace(/(^_+)|(_+$)/g, '') + '_unhappy'
         },
         errorEl = $(error.id).length > 0 ? $(error.id) : getError(error);
         


### PR DESCRIPTION
Convert selectors like `[name="boo[foo]"]` to `name_boo_foo_unhappy`. The current behaviour (stripping off the first character) causes complex selectors to break on mobile WebKit (throwing DOM exceptions).
