### PR TITLE
Return this to support method chaining

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -92,5 +92,6 @@
     } else {
       this.bind('submit', handleSubmit);
     }
+    return this;
   };
 })(this.jQuery || this.Zepto);

--- a/test/tests.js
+++ b/test/tests.js
@@ -311,3 +311,8 @@ test("test included phone validator", function () {
         ok(!happy.USPhone(sadPhones[i]));
     }
 });
+
+test("check return value", function () {
+    var form = fixture('');
+    equal(form.isHappy({fields: {}}), form);
+});


### PR DESCRIPTION
Since the plugin doesn't return anything yet (though the name might suggest a boolean result) it would be nice if it returned `this` to support method chaining.
