### PR TITLE
allows "+" in email addresses, which is valid.

### DIFF
--- a/happy.methods.js
+++ b/happy.methods.js
@@ -9,7 +9,7 @@ var happy = {
   },
   
   email: function (val) {
-    return /^(?:\w+\.?)*\w+@(?:\w+\.)+\w+$/.test(val);
+    return /^(?:\w+\.?\+?)*\w+@(?:\w+\.)+\w+$/.test(val);
   },
   
   minLength: function (val, length) {


### PR DESCRIPTION
My biggest pet peeve these days are validators that don't allow a plus (+) sign in the email address. It IS a valid email address with a +.
