### PR TITLE
Accessibilty Imporovements

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -6,7 +6,7 @@
     var fields = [], item;
 
     function getError(error) {
-      return $('<span id="'+error.id+'" class="unhappyMessage">'+error.message+'</span>');
+      return $('<span id="'+error.id+'" class="unhappyMessage" role="alert">'+error.message+'</span>');
     }
     function handleSubmit() {
       var errors = false, i, l;


### PR DESCRIPTION
### Changed to **after**(errorEl) for the sake of screenreaders

→ Screenreaders don't automatically "see" DOM elements inserted before inputs
→ Inserting errors after the relevant input allows blind people to easily recieve these errors if the site uses happy.js
→ Where I learned this was: [alistapart.com/article/designing-for-easy-interaction](http://alistapart.com/article/designing-for-easy-interaction)
### Added role=alert for accessibility too
