### PR TITLE
Fixes .when attribute

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -89,7 +89,7 @@
                     return true;
                 }
             };
-            field.bind(opts.when || 'blur', field.testValid);
+            field.bind(opts.when || config.when || 'blur', field.testValid);
         }
 
         for (item in config.fields) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -378,3 +378,52 @@ test('custom error template', function () {
     equal($('.customUnhappy').length, 1);
 
 });
+
+test('test attribute when to be set on all fields', function () {
+    var form = fixture('<input type="text" id="textInput1" />');
+
+    form.isHappy({
+        fields: {
+            '#textInput1': {
+                test: happy.email
+            },
+            '#textInput2': {
+                test: happy.email
+            }
+        },
+        when: 'keyup',
+        testMode: true
+    });
+
+    $('#textInput1').val('sademail').trigger('blur');
+    equal($('.unhappy').length, 0);
+    $('#textInput1').val('sademail').trigger('keyup');
+    equal($('.unhappy').length, 1);
+    $('#textInput1').val('happy@email.com').trigger('keyup');
+    equal($('.unhappy').length, 0);
+    $('#textInput2').val('happy@email.com').trigger('keyup');
+    equal($('.unhappy').length, 0);
+});
+
+test('test attribute when to be set on a unique field', function () {
+    var form = fixture('<input type="text" id="textInput1" /><input type="text" id="textInput2" />');
+
+    form.isHappy({
+        fields: {
+            '#textInput1': {
+                test: happy.email
+            },
+            '#textInput2': {
+                test: happy.email,
+                when: 'keyup'
+            }
+        },
+        testMode: true
+    });
+
+    $('#textInput1').val('sademail').trigger('keyup');
+    equal($('.unhappy').length, 0);
+    $('#textInput2').val('sademail').trigger('keyup');
+    equal($('.unhappy').length, 1);
+
+});


### PR DESCRIPTION
From documentation it looks like that `when` is a attribute of `<input>`. This way you can configure a different event for each input:

```
$('#awesomeForm').isHappy({
  fields: {
    // reference the field you're talking about, probably by `id`
    // but you could certainly do $('[name=name]') as well.
    '#yourName': {
      required: true,
      message: 'Might we inquire your name',
      when: 'keyup'
    }
  },
});
```

Previously the attribute was set over the `fields` object, if you set this value it will change the event for all fields.
