### PR TITLE
Refactor triggering of form validation

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -52,7 +52,7 @@
                 id: selector.slice(1) + '_unhappy'
             };
             var errorEl = $(error.id).length > 0 ? $(error.id) : getError(error);
-            var handleBlur = function handleBlur() {
+            var triggerValidation = function triggerValidation() {
                 if (!pauseMessages) {
                     field.testValid();
                 } else {
@@ -86,7 +86,7 @@
                 gotFunc = ((val.length > 0 || required === 'sometimes') && isFunction(opts.test));
 
                 // check if we've got an error on our hands
-                if (submit === true && required === true && val.length === 0) {
+                if (required === true && val.length === 0) {
                     error = true;
                 } else if (gotFunc) {
                     error = !opts.test(val, arg);
@@ -105,7 +105,16 @@
                     return true;
                 }
             };
-            field.bind(opts.when || config.when || 'blur', handleBlur);
+
+            var triggers = opts.when || config.when || ['blur', 'keyup'];
+            if (triggers instanceof Array) {
+                for (var i = 0; i < triggers.length; i++) {
+                    console.log(triggers[i]);
+                    field.bind(triggers[i], triggerValidation);
+                }
+            } else {
+                field.bind(triggers, triggerValidation);
+            }
         }
 
         for (item in config.fields) {


### PR DESCRIPTION
This is a response to #39.  It makes sense to not have error messages disappear when the blur event occurs.  But while we're talking about UX for error handling, it also feels weird to have to click away from the input to make an error disappear in general.  Would it be better to have fields be validated by default on both blur and keyup?

The only weird issue I see with this is having a field be validated while the user is typing for the very first time.  That is if I'm typing in my email I don't want to get an error the first time I put in 's'.  So basically after the first blur event is when keyup validation should start.

And if by default forms are validated on multiple events, users should be able to pass in multiple events as well, so I made the 'when' option compatible with arrays.

This isn't mergable yet, just wondering if people think this is a good idea before I finish this up & add tests.

Changes:
-Validate required fields not just on submit
-Validate on blur and keyup by default instead of just blur
-Allow users to pass in array of events for validation to occur on