### PR TITLE
new option error_target

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -1,4 +1,3 @@
-// Happy validation, see http://happyjs.com/
 /*global $*/
 (function happyJS($) {
     function trim(el) {


### PR DESCRIPTION
This is useful to ensure only 1 error is shown per control group, and lets you control its location (say below the checkboxes).

Example usage:

```
$('#form').isHappy({
      fields: {
       'input[name=style]': {
          required: true,
          message: 'What style of photos do you prefer?',
          error_target: '#style',
          when: 'change',
          test: function(){ 
            return $('input[name=style]').is(':checked');
          },
        },
    });
```
