### PR TITLE
preventDefault when testing

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -20,7 +20,7 @@
             }
             return defaultError(error);
         }
-        function handleSubmit() {
+        function handleSubmit(e) {
             var  i, l;
             var errors = false;
             for (i = 0, l = fields.length; i < l; i += 1) {
@@ -32,9 +32,9 @@
                 if (isFunction(config.unHappy)) config.unHappy();
                 return false;
             } else if (config.testMode) {
-                if (isFunction(config.happy)) return config.happy();
+                e.preventDefault();
                 if (window.console) console.warn('would have submitted');
-                return false;
+                if (isFunction(config.happy)) return config.happy();
             }
             if (isFunction(config.happy)) return config.happy();
         }


### PR DESCRIPTION
When running the unit tests, I noticed the page kept reloading. I was able to determine the issue was due to the `return false;` never getting hit when `config.happy` was present. It was getting returned and the `return false;` was never getting hit. The `return false;` isn't necessary with `preventDefault()` present.