### PR TITLE
add validate failed callback with detail error info

### DIFF
--- a/happy.js
+++ b/happy.js
@@ -129,6 +129,7 @@
                 }
 
                 if (testResult) {
+                    if (isFunction(config.error)) config.error(error);
                     errorTarget.addClass(fieldErrorClass).after(errorEl);
                     return false;
                 } else {


### PR DESCRIPTION
When validate field failed,callback error function in custom config.
Because the args of unHappy is not easily to get error message, in other word, I never find error message in unHappy's args

If I want to exec my js when validate failed with error message, I think this is a good way to achieve it.