### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-#Happy.js – are your forms happy? Just ask 'em!
+# Happy.js – are your forms happy? Just ask 'em!
 
 [http://projects.joreteg.com/Happy.js/](http://projects.joreteg.com/Happy.js/) | [Demo](http://projects.joreteg.com/Happy.js/demo.html)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
